### PR TITLE
use localized text for crop names, seed names, and descriptions

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -25,7 +25,7 @@ const OASIS_STOCK_IDS = [478, 486, 494, 802];
 
 const OUTPUT_PATH = path.resolve(__dirname, 'parsed-crop-data.json');
 const CROPS_PATH = path.resolve(__dirname, 'Crops.xnb');
-const OBJECT_INFORMATION_PATH = path.resolve(__dirname, 'ObjectInformation.xnb');
+const OBJECT_INFORMATION_PATH = path.resolve(__dirname, fs.readdirSync(__dirname).filter(file => file.match(/ObjectInformation(\.[a-z]{2}\-[A-Z]{2})?\.xnb/))[0] || "ObjectInformation.xnb");
 
 // Check Stardew Valley data files exist
 [CROPS_PATH, OBJECT_INFORMATION_PATH].forEach((filePath) => {
@@ -73,10 +73,10 @@ Object.keys(crops.content).forEach((key) => {
   const crop = {};
 
   /**
-   * Crop's name
+   * Crop's name (localized)
    * @type {string}
    */
-  crop.name = cropInfoData[0];
+  crop.name = cropInfoData[4];
 
   /**
    * Crop's description
@@ -190,10 +190,10 @@ Object.keys(crops.content).forEach((key) => {
   crop.seed = {};
 
   /**
-   * Seed's name
+   * Seed's name (localized)
    * @type {string}
    */
-  crop.seed.name = seedInfoData[0];
+  crop.seed.name = seedInfoData[4];
 
   /**
    * Seed's description


### PR DESCRIPTION
Hello,

I poked around in the xnb files and the json that this produces and found that the first item in the cropInfoData list is in English only for reference, and the strings that get localized across all of the ObjectInformation files are towards the end. I updated the indices to work with ObjectInformation files in other languages, and updated the OBJECT_INFORMATION_PATH declaration to accept the filenames for non-English xnb files.

This should account for issue #13